### PR TITLE
Use NengoTestLoader to run individual tests

### DIFF
--- a/nengo_ocl/test/test_sim_npy2.py
+++ b/nengo_ocl/test/test_sim_npy2.py
@@ -27,16 +27,7 @@ def simulator_allocator(model):
 
 load_tests = nengo.tests.helpers.load_nengo_tests(simulator_allocator)
 
-for foo in load_tests(None, None, None):
-    class MyCLS(foo.__class__):
-        def Simulator(self, model):
-            return simulator_allocator(model)
-    globals()[foo.__class__.__name__] = MyCLS
-    MyCLS.__name__ = foo.__class__.__name__
-    del MyCLS
-    del foo
-del load_tests
-
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(
+        testLoader=nengo.tests.helpers.NengoTestLoader(simulator_allocator))


### PR DESCRIPTION
Now possible to run individual tests with
`python nengo_ocl/test/test_sim_npy2.py <module>.<class>.<function>`
where class and function are optional.

E.g.,

```
>>> python nengo_ocl/test/test_sim_npy2.py
EEEEEEEEE...EE
...
----------------------------------------------------------------------
Ran 14 tests in 3.891s

FAILED (errors=11)

>>> python nengo_ocl/test/test_sim_npy2.py test_simulator
EE
...
----------------------------------------------------------------------
Ran 2 tests in 0.002s

FAILED (errors=2)
>>> python nengo_ocl/test/test_sim_npy2.py test_simulator.TestSimulator.test_simple_direct_mode
E
...
----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```
