### PR TITLE
Changed sim.copied to sim.get

### DIFF
--- a/nengo_ocl/test/test_ast_conversion.py
+++ b/nengo_ocl/test/test_ast_conversion.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 import math
 import inspect
@@ -89,7 +88,7 @@ class TestAstConversion(unittest.TestCase):
 
         out = []
         for s in output_signals:
-            out.append(sim.signals[sim.copied(s)])
+            out.append(sim.signals[sim.model.memo[id(s)]])
 
         return out
 
@@ -249,3 +248,6 @@ class TestAstConversion(unittest.TestCase):
                            "to OCL with multiple lambda functions in a source line")
         except NotImplementedError:
             pass
+
+if __name__ == '__main__':
+   unittest.main()

--- a/nengo_ocl/test/test_clra_nonlinearities.py
+++ b/nengo_ocl/test/test_clra_nonlinearities.py
@@ -1,9 +1,8 @@
-
-import nose
 import numpy as np
+from nengo_ocl.tricky_imports import unittest
 
 import nengo
-from nengo.objects import LIF, LIFRate, Direct
+from nengo.core import LIF, LIFRate, Direct
 
 import pyopencl as cl
 ctx = cl.create_some_context()
@@ -12,158 +11,160 @@ import logging
 logger = logging.getLogger(__name__)
 # nengo.log(True)
 
-from ..ra_gemv import ragged_gather_gemv
-from  .. import raggedarray as ra
-from  ..raggedarray import RaggedArray as RA
-from ..clraggedarray import CLRaggedArray as CLRA
+from nengo_ocl.ra_gemv import ragged_gather_gemv
+from nengo_ocl import raggedarray as ra
+from nengo_ocl.raggedarray import RaggedArray as RA
+from nengo_ocl.clraggedarray import CLRaggedArray as CLRA
 
-# from ..clra_nonlinearities import plan_lif, plan_lif_rate
-from ..clra_nonlinearities import *
+from nengo_ocl.clra_nonlinearities import *
 
 def not_close(a, b, rtol=1e-3, atol=1e-3):
     return np.abs(a - b) > atol + rtol * np.abs(b)
 
-def test_lif_step0():
-    test_lif_step(upsample=1, n_elements=0)
+class Test_CLRA_Nonlinearities(unittest.TestCase):
+    def test_lif_step0(self):
+        self.test_lif_step(upsample=1, n_elements=0)
 
-def test_lif_step1():
-    test_lif_step(upsample=4, n_elements=0)
+    def test_lif_step1(self):
+        self.test_lif_step(upsample=4, n_elements=0)
 
-def test_lif_step2():
-    test_lif_step(upsample=4, n_elements=7)
+    def test_lif_step2(self):
+        self.test_lif_step(upsample=4, n_elements=7)
 
-def test_lif_step(upsample=1, n_elements=0):
-    """Test the lif nonlinearity, comparing one step with the Numpy version."""
-    dt = 1e-3
-    # n_neurons = [3, 3, 3]
-    n_neurons = [12345, 23456, 34567]
-    N = len(n_neurons)
-    J = RA([np.random.normal(scale=1.2, size=n) for n in n_neurons])
-    V = RA([np.random.uniform(low=0, high=1, size=n) for n in n_neurons])
-    W = RA([np.random.uniform(low=-5*dt, high=5*dt, size=n) for n in n_neurons])
-    OS = RA([np.zeros(n) for n in n_neurons])
+    def test_lif_step(self, upsample=1, n_elements=0):
+        """Test the lif nonlinearity, comparing one step with the Numpy version."""
+        dt = 1e-3
+        # n_neurons = [3, 3, 3]
+        n_neurons = [12345, 23456, 34567]
+        N = len(n_neurons)
+        J = RA([np.random.normal(scale=1.2, size=n) for n in n_neurons])
+        V = RA([np.random.uniform(low=0, high=1, size=n) for n in n_neurons])
+        W = RA([np.random.uniform(low=-5*dt, high=5*dt, size=n) for n in n_neurons])
+        OS = RA([np.zeros(n) for n in n_neurons])
 
-    ref = 2e-3
-    # tau = 20e-3
-    # refs = list(np.random.uniform(low=1.7e-3, high=4.2e-3, size=len(n_neurons)))
-    taus = list(np.random.uniform(low=15e-3, high=80e-3, size=len(n_neurons)))
+        ref = 2e-3
+        # tau = 20e-3
+        # refs = list(np.random.uniform(low=1.7e-3, high=4.2e-3, size=len(n_neurons)))
+        taus = list(np.random.uniform(low=15e-3, high=80e-3, size=len(n_neurons)))
 
-    queue = cl.CommandQueue(ctx)
-    clJ = CLRA(queue, J)
-    clV = CLRA(queue, V)
-    clW = CLRA(queue, W)
-    clOS = CLRA(queue, OS)
-    # clRef = CLRA(queue, RA(refs))
-    clTau = CLRA(queue, RA(taus))
+        queue = cl.CommandQueue(ctx)
+        clJ = CLRA(queue, J)
+        clV = CLRA(queue, V)
+        clW = CLRA(queue, W)
+        clOS = CLRA(queue, OS)
+        # clRef = CLRA(queue, RA(refs))
+        clTau = CLRA(queue, RA(taus))
 
-    ### simulate host
-    nls = [LIF(n, tau_ref=ref, tau_rc=taus[i])
-           for i, n in enumerate(n_neurons)]
-    for i, nl in enumerate(nls):
-        if upsample <= 1:
-            nl.step_math0(dt, J[i], V[i], W[i], OS[i])
+        ### simulate host
+        nls = [LIF(n, tau_ref=ref, tau_rc=taus[i])
+               for i, n in enumerate(n_neurons)]
+        for i, nl in enumerate(nls):
+            if upsample <= 1:
+                nl.step_math0(dt, J[i], V[i], W[i], OS[i])
+            else:
+                s = np.zeros_like(OS[i])
+                for j in xrange(upsample):
+                    nl.step_math0(dt/upsample, J[i], V[i], W[i], s)
+                    OS[i] = (OS[i] > 0.5) | (s > 0.5)
+
+        ### simulate device
+        plan = plan_lif(queue, clJ, clV, clW, clV, clW, clOS, ref, clTau, dt,
+                        n_elements=n_elements, upsample=upsample)
+        plan()
+
+        if 1:
+            a, b = V, clV
+            for i in xrange(len(a)):
+                nc, _ = not_close(a[i], b[i]).nonzero()
+                if len(nc) > 0:
+                    j = nc[0]
+                    print "i", i, "j", j
+                    print "J", J[i][j], clJ[i][j]
+                    print "V", V[i][j], clV[i][j]
+                    print "W", W[i][j], clW[i][j]
+                    print "...", len(nc) - 1, "more"
+
+        n_spikes = np.sum([np.sum(os) for os in OS])
+        if n_spikes < 1.0:
+            logger.warn("LIF spiking mechanism was not tested!")
+        assert ra.allclose(J, clJ.to_host())
+        assert ra.allclose(V, clV.to_host())
+        assert ra.allclose(W, clW.to_host())
+        assert ra.allclose(OS, clOS.to_host())
+
+    def test_lif_speed(self, heterogeneous=True):
+        """Test the speed of the lif nonlinearity
+
+        heterogeneous: if true, use a wide range of population sizes.
+        """
+
+        dt = 1e-3
+        ref = 2e-3
+        tau = 20e-3
+
+        if heterogeneous:
+            n_neurons = [1.0e5] * 5 + [1e3]*50
         else:
-            s = np.zeros_like(OS[i])
-            for j in xrange(upsample):
-                nl.step_math0(dt/upsample, J[i], V[i], W[i], s)
-                OS[i] = (OS[i] > 0.5) | (s > 0.5)
+            n_neurons = [1.1e5] * 5
 
-    ### simulate device
-    plan = plan_lif(queue, clJ, clV, clW, clV, clW, clOS, ref, clTau, dt,
-                    n_elements=n_elements, upsample=upsample)
-    plan()
+        J = RA([np.random.randn(n) for n in n_neurons])
+        V = RA([np.random.uniform(low=0, high=1, size=n) for n in n_neurons])
+        W = RA([np.random.uniform(low=-10*dt, high=10*dt, size=n) for n in n_neurons])
+        OS = RA([np.zeros(n) for n in n_neurons])
 
-    if 1:
-        a, b = V, clV
-        for i in xrange(len(a)):
-            nc, _ = not_close(a[i], b[i]).nonzero()
-            if len(nc) > 0:
-                j = nc[0]
-                print "i", i, "j", j
-                print "J", J[i][j], clJ[i][j]
-                print "V", V[i][j], clV[i][j]
-                print "W", W[i][j], clW[i][j]
-                print "...", len(nc) - 1, "more"
+        queue = cl.CommandQueue(
+            ctx, properties=cl.command_queue_properties.PROFILING_ENABLE)
 
-    n_spikes = np.sum([np.sum(os) for os in OS])
-    if n_spikes < 1.0:
-        logger.warn("LIF spiking mechanism was not tested!")
-    assert ra.allclose(J, clJ.to_host())
-    assert ra.allclose(V, clV.to_host())
-    assert ra.allclose(W, clW.to_host())
-    assert ra.allclose(OS, clOS.to_host())
+        clJ = CLRA(queue, J)
+        clV = CLRA(queue, V)
+        clW = CLRA(queue, W)
+        clOS = CLRA(queue, OS)
 
-def test_lif_speed(heterogeneous=True):
-    """Test the speed of the lif nonlinearity
+        n_elements = [0, 2, 5, 10]
+        for i, nel in enumerate(n_elements):
+            plan = plan_lif(queue, clJ, clV, clW, clV, clW, clOS, ref, tau, dt,
+                            n_elements=nel)
 
-    heterogeneous: if true, use a wide range of population sizes.
-    """
+            for j in range(1000):
+                plan(profiling=True)
 
-    dt = 1e-3
-    ref = 2e-3
-    tau = 20e-3
+            print "plan %d: n_elements = %d" % (i, nel)
+            print 'n_calls         ', plan.n_calls
+            print 'queued -> submit', plan.atime
+            print 'submit -> start ', plan.btime
+            print 'start -> end    ', plan.ctime
 
-    if heterogeneous:
-        n_neurons = [1.0e5] * 5 + [1e3]*50
-    else:
-        n_neurons = [1.1e5] * 5
+    def test_lif_rate(self, n_elements=0):
+        """Test the `lif_rate` nonlinearity"""
+        # n_neurons = [3, 3, 3]
+        n_neurons = [123459, 23456, 34567]
+        N = len(n_neurons)
+        J = RA([np.random.normal(loc=1, scale=10, size=n) for n in n_neurons])
+        R = RA([np.zeros(n) for n in n_neurons])
 
-    J = RA([np.random.randn(n) for n in n_neurons])
-    V = RA([np.random.uniform(low=0, high=1, size=n) for n in n_neurons])
-    W = RA([np.random.uniform(low=-10*dt, high=10*dt, size=n) for n in n_neurons])
-    OS = RA([np.zeros(n) for n in n_neurons])
+        ref = 2e-3
+        taus = list(np.random.uniform(low=15e-3, high=80e-3, size=len(n_neurons)))
 
-    queue = cl.CommandQueue(
-        ctx, properties=cl.command_queue_properties.PROFILING_ENABLE)
+        queue = cl.CommandQueue(ctx)
+        clJ = CLRA(queue, J)
+        clR = CLRA(queue, R)
+        clTau = CLRA(queue, RA(taus))
 
-    clJ = CLRA(queue, J)
-    clV = CLRA(queue, V)
-    clW = CLRA(queue, W)
-    clOS = CLRA(queue, OS)
+        ### simulate host
+        nls = [LIF(n, tau_ref=ref, tau_rc=taus[i])
+               for i, n in enumerate(n_neurons)]
+        for i, nl in enumerate(nls):
+            R[i] = nl.rates(J[i].flatten()).reshape((-1,1))
 
-    n_elements = [0, 2, 5, 10]
-    for i, nel in enumerate(n_elements):
-        plan = plan_lif(queue, clJ, clV, clW, clV, clW, clOS, ref, tau, dt,
-                        n_elements=nel)
+        ### simulate device
+        plan = plan_lif_rate(queue, clJ, clR, ref, clTau, n_elements=n_elements)
+        plan()
 
-        for j in range(1000):
-            plan(profiling=True)
+        rate_sum = np.sum([np.sum(r) for r in R])
+        if rate_sum < 1.0:
+            logger.warn("LIF rate was not tested above the firing threshold!")
+        assert ra.allclose(J, clJ.to_host())
+        assert ra.allclose(R, clR.to_host())
 
-        print "plan %d: n_elements = %d" % (i, nel)
-        print 'n_calls         ', plan.n_calls
-        print 'queued -> submit', plan.atime
-        print 'submit -> start ', plan.btime
-        print 'start -> end    ', plan.ctime
-
-def test_lif_rate(n_elements=0):
-    """Test the `lif_rate` nonlinearity"""
-    # n_neurons = [3, 3, 3]
-    n_neurons = [123459, 23456, 34567]
-    N = len(n_neurons)
-    J = RA([np.random.normal(loc=1, scale=10, size=n) for n in n_neurons])
-    R = RA([np.zeros(n) for n in n_neurons])
-
-    ref = 2e-3
-    taus = list(np.random.uniform(low=15e-3, high=80e-3, size=len(n_neurons)))
-
-    queue = cl.CommandQueue(ctx)
-    clJ = CLRA(queue, J)
-    clR = CLRA(queue, R)
-    clTau = CLRA(queue, RA(taus))
-
-    ### simulate host
-    nls = [LIF(n, tau_ref=ref, tau_rc=taus[i])
-           for i, n in enumerate(n_neurons)]
-    for i, nl in enumerate(nls):
-        R[i] = nl.rates(J[i].flatten()).reshape((-1,1))
-
-    ### simulate device
-    plan = plan_lif_rate(queue, clJ, clR, ref, clTau, n_elements=n_elements)
-    plan()
-
-    rate_sum = np.sum([np.sum(r) for r in R])
-    if rate_sum < 1.0:
-        logger.warn("LIF rate was not tested above the firing threshold!")
-    assert ra.allclose(J, clJ.to_host())
-    assert ra.allclose(R, clR.to_host())
-
+if __name__ == '__main__':
+   unittest.main()

--- a/nengo_ocl/test/test_clraggedarray.py
+++ b/nengo_ocl/test/test_clraggedarray.py
@@ -1,10 +1,10 @@
-
-import nose
 import numpy as np
-from ..ra_gemv import ragged_gather_gemv
-from  .. import raggedarray as ra
+from nengo_ocl.tricky_imports import unittest
+
+from nengo_ocl.ra_gemv import ragged_gather_gemv
+from nengo_ocl import raggedarray as ra
 RA = ra.RaggedArray
-from ..clraggedarray import CLRaggedArray as CLRA
+from nengo_ocl.clraggedarray import CLRaggedArray as CLRA
 
 import pyopencl as cl
 ctx = cl.create_some_context()
@@ -20,42 +20,46 @@ def make_random_pair(n, d=1, low=20, high=40):
     clA = CLRA(queue, A)
     return A, clA
 
-def test_unit():
-    val = np.random.randn()
-    A = RA([val])
+class TestCLRaggedArray(unittest.TestCase):
+    def test_unit(self):
+        val = np.random.randn()
+        A = RA([val])
 
-    queue = cl.CommandQueue(ctx)
-    clA = CLRA(queue, A)
-    assert np.allclose(val, clA[0])
+        queue = cl.CommandQueue(ctx)
+        clA = CLRA(queue, A)
+        assert np.allclose(val, clA[0])
 
-def test_small():
-    n = 3
-    sizes = [3] * 3
-    vals = [np.random.normal(size=size) for size in sizes]
-    A = RA(vals)
+    def test_small(self):
+        n = 3
+        sizes = [3] * 3
+        vals = [np.random.normal(size=size) for size in sizes]
+        A = RA(vals)
 
-    queue = cl.CommandQueue(ctx)
-    clA = CLRA(queue, A)
-    assert ra.allclose(A, clA.to_host())
+        queue = cl.CommandQueue(ctx)
+        clA = CLRA(queue, A)
+        assert ra.allclose(A, clA.to_host())
 
-def test_random_vectors():
-    n = np.random.randint(low=5, high=10)
-    A, clA = make_random_pair(n, 1, low=3000, high=4000)
-    assert ra.allclose(A, clA.to_host())
+    def test_random_vectors(self):
+        n = np.random.randint(low=5, high=10)
+        A, clA = make_random_pair(n, 1, low=3000, high=4000)
+        assert ra.allclose(A, clA.to_host())
 
-def test_random_matrices():
-    n = np.random.randint(low=5, high=10)
-    A, clA = make_random_pair(n, 2, low=20, high=40)
-    assert ra.allclose(A, clA.to_host())
+    def test_random_matrices(self):
+        n = np.random.randint(low=5, high=10)
+        A, clA = make_random_pair(n, 2, low=20, high=40)
+        assert ra.allclose(A, clA.to_host())
 
-def test_getitem():
-    """Try getting a single item with a single index"""
-    A, clA = make_random_pair(5, 2)
-    s = 3
-    assert np.allclose(A[s], clA[s])
+    def test_getitem(self):
+        """Try getting a single item with a single index"""
+        A, clA = make_random_pair(5, 2)
+        s = 3
+        assert np.allclose(A[s], clA[s])
 
-def test_getitems():
-    """Try getting multiple items using a list of indices"""
-    A, clA = make_random_pair(10, 2)
-    s = [1,3,7,8]
-    assert ra.allclose(A[s], clA[s].to_host())
+    def test_getitems(self):
+        """Try getting multiple items using a list of indices"""
+        A, clA = make_random_pair(10, 2)
+        s = [1,3,7,8]
+        assert ra.allclose(A[s], clA[s].to_host())
+
+if __name__ == '__main__':
+   unittest.main()


### PR DESCRIPTION
This simplified some example syntax, and is done for the ref simulator in [nengo/#163](https://github.com/ctn-waterloo/nengo/pull/163).

Should things like this be part of some base class that all simulators inherit from?

I also converted some unit tests to use the `unittest` module while I was at it; but, I'm unable to get all of the tests to pass. I get

```
Ran 111 tests in 186.108s
FAILED (failures=3, errors=35)
```

though, before this change, I got

```
Ran 101 tests in 193.515s
FAILED (failures=1, errors=27)
```

so the additional errors are likely tests that weren't running before. Not sure if this is due to my setup or old tests.
