### PR TITLE
Use nengo.builder.Builder

### DIFF
--- a/nengo_ocl/sim_ocl.py
+++ b/nengo_ocl/sim_ocl.py
@@ -1,4 +1,3 @@
-
 import os
 import collections
 import numpy as np
@@ -29,8 +28,8 @@ class Simulator(sim_npy.Simulator):
         else:
             return CLRaggedArray(self.queue, val)
 
-    def __init__(self, model, context=None, n_prealloc_probes=1000,
-                 profiling=None, ocl_only=False):
+    def __init__(self, model, dt=0.001, seed=None, builder=None, context=None,
+                 n_prealloc_probes=1000, profiling=None, ocl_only=False):
         if context is None:
             print 'No context argument was provided to sim_ocl.Simulator'
             print "Calling pyopencl.create_some_context() for you now:"
@@ -49,7 +48,8 @@ class Simulator(sim_npy.Simulator):
         self.ocl_only = ocl_only
 
         # -- allocate data
-        sim_npy.Simulator.__init__(self, model)
+        sim_npy.Simulator.__init__(
+            self, model=model, dt=dt, seed=seed, builder=builder)
 
         # -- set up the DAG for executing OCL kernels
         self._plandict = OrderedDict()

--- a/nengo_ocl/test/test_ast_conversion.py
+++ b/nengo_ocl/test/test_ast_conversion.py
@@ -3,9 +3,7 @@ import math
 import inspect
 
 import nengo
-import nengo.core
-import nengo.simulator
-from nengo.core import Signal
+from nengo.builder import Signal, Constant, SimDirect
 
 import nengo_ocl
 from nengo_ocl.tricky_imports import unittest
@@ -79,8 +77,8 @@ class TestAstConversion(unittest.TestCase):
         output_signals = []
         for i, xx in enumerate(x):
             s = model.add(Signal(n=out_dims, name="output_%d" % i))
-            model._operators.append(nengo.simulator.SimDirect(
-                    s, nengo.core.Constant(xx, name="input_%d" % i), FunctionObject))
+            model._operators.append(SimDirect(
+                    s, Constant(xx, name="input_%d" % i), FunctionObject))
             output_signals.append(s)
 
         sim = model.simulator(sim_class=OclSimulator)

--- a/nengo_ocl/test/test_clra_nonlinearities.py
+++ b/nengo_ocl/test/test_clra_nonlinearities.py
@@ -2,7 +2,7 @@ import numpy as np
 from nengo_ocl.tricky_imports import unittest
 
 import nengo
-from nengo.core import LIF, LIFRate, Direct
+from nengo.nonlinearities import LIF, LIFRate, Direct
 
 import pyopencl as cl
 ctx = cl.create_some_context()

--- a/nengo_ocl/test/test_sim_npy.py
+++ b/nengo_ocl/test/test_sim_npy.py
@@ -14,11 +14,11 @@ from nengo.tests.helpers import NengoTestLoader
 from nengo.tests.helpers import load_nengo_tests
 from nengo_ocl import sim_npy
 
-def Npy2Simulator(model):
-    return sim_npy.Simulator(model)
+from nengo.tests.test_simulator import TestSimulator, TestNonlinear
+TestSimulator.Simulator = sim_npy.Simulator
+TestNonlinear.Simulator = sim_npy.Simulator
 
-load_tests = load_nengo_tests(Npy2Simulator)
+load_tests = load_nengo_tests(sim_npy.Simulator)
 
 if __name__ == '__main__':
-   unittest.main(testLoader=NengoTestLoader(Npy2Simulator))
-
+   unittest.main(testLoader=NengoTestLoader(sim_npy.Simulator))

--- a/nengo_ocl/test/test_sim_ocl.py
+++ b/nengo_ocl/test/test_sim_ocl.py
@@ -18,11 +18,16 @@ import pyopencl as cl
 
 ctx = cl.create_some_context()
 
-def Ocl2Simulator(model):
-    return sim_ocl.Simulator(model, ctx)
+def Ocl2Simulator(*args, **kwargs):
+    kwargs['context'] = ctx
+    return sim_ocl.Simulator(*args, **kwargs)
+
+from nengo.tests.test_simulator import TestSimulator, TestNonlinear
+TestSimulator.Simulator = staticmethod(Ocl2Simulator)
+TestNonlinear.Simulator = staticmethod(Ocl2Simulator)
 
 load_tests = load_nengo_tests(Ocl2Simulator)
 
+
 if __name__ == '__main__':
    unittest.main(testLoader=NengoTestLoader(Ocl2Simulator))
-


### PR DESCRIPTION
- Also various changes due to refactoring in Nengo PR #177
- TestSimulator is now explicitly imported, as not all simulators are expected to pass these tests (but these are valid for the OpenCL backend, for now)
- Also fixes a lif_rate bug due to recent LIF changes

Merging this should wait until https://github.com/ctn-waterloo/nengo/pull/177 is merged.
