### PR TITLE
Fixed vector length check in ast_conversion.py

### DIFF
--- a/nengo_ocl/ast_conversion.py
+++ b/nengo_ocl/ast_conversion.py
@@ -418,9 +418,9 @@ class OCL_Translator(ast.NodeVisitor):
     builtins = __builtin__.__dict__
 
     def _check_vector_length(self, length):
-        assert length > self.MAX_VECTOR_LENGTH, (
-            "Vectors of length >%s are not supported"
-            % self.MAX_VECTOR_LENGTH)
+        if length > self.MAX_VECTOR_LENGTH:
+            raise ValueError("Vectors of length >%s are not supported"
+                             % self.MAX_VECTOR_LENGTH)
 
     def __init__(self, source, globals_dict, closure_dict,
                  in_dim=None, out_dim=None):

--- a/nengo_ocl/sim_ocl.py
+++ b/nengo_ocl/sim_ocl.py
@@ -122,7 +122,7 @@ class Simulator(sim_npy.Simulator):
                 plan = plan_direct(self.queue, ocl_fn.code, ocl_fn.init,
                                    Xname, X, Y, tag=fn_name)
                 plans.append(plan)
-            except (NotImplementedError, AssertionError), e:
+            except Exception as e:
                 if self.ocl_only:
                     raise e
 


### PR DESCRIPTION
- Changed this back to how it was before
- I'm catching all exceptions now in sim_ocl, so any function that fails to convert for any reason will be done in Python.
