### PR TITLE
Change Nengo testing to py.test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+.cache
 
 # Translations
 *.mo

--- a/nengo_ocl/test/conftest.py
+++ b/nengo_ocl/test/conftest.py
@@ -1,0 +1,1 @@
+from nengo.tests.conftest import *

--- a/nengo_ocl/test/test_sim_npy.py
+++ b/nengo_ocl/test/test_sim_npy.py
@@ -2,36 +2,55 @@
 Black-box testing of the sim_npy Simulator.
 
 TestCase classes are added automatically from
-nengo.tests.helpers.simulator_test_cases, but
-you can still run individual test files like this:
+nengo.tests, but you can still run individual
+test files like this:
 
-$ python test/test_sim_npy.py test_ensemble.TestEnsemble.test_lifrate
+$ py.test test/test_sim_npy.py -k test_ensemble.test_scalar
+
+See http://pytest.org/latest/usage.html for more invocations.
 
 """
 
-from nengo_ocl.tricky_imports import unittest
-from nengo.tests.helpers import NengoTestLoader
-from nengo.tests.helpers import load_nengo_tests
-import nengo.tests.test_simulator
+import inspect
+import os.path
+
+import nengo.tests
+import pytest
+
 from nengo_ocl import sim_npy
 
-# -- these TestSimulator and TestNonlinear are handled differently because
-# NengoTestLoader only picks up subclasses of SimulatorTestCase. TestSimulat
-# and TestNonlinear in nengo do not inherit from SimulatorTestCase.  The
-# semantics of SimulatorTestCase can be understood as being "These should pass
-# for ANY Simulator". TestSimulator and TestNonlinear are stricter tests of
-# the reference simulator's API, which we also attempt to pass, because we can
-# so why not.
 
-class TestSimulator(nengo.tests.test_simulator.TestSimulator):
-    Simulator = sim_npy.Simulator
+def pytest_funcarg__Simulator(request):
+    """the Simulator class being tested.
+
+    For this file, it's sim_npy.Simulator.
+    """
+    return sim_npy.Simulator
 
 
-class TestNonlinear(nengo.tests.test_simulator.TestNonlinear):
-    Simulator = sim_npy.Simulator
+def pytest_funcarg__RefSimulator(request):
+    """the Simulator class being tested.
+
+    For this file, it's sim_npy.Simulator.
+    """
+    return sim_npy.Simulator
 
 
-load_tests = load_nengo_tests(sim_npy.Simulator)
+nengotestdir = os.path.dirname(nengo.tests.__file__)
+
+for testfile in os.listdir(nengotestdir):
+    if not testfile.startswith('test_') or not testfile.endswith('.py'):
+        continue
+    m = __import__("nengo.tests." + testfile[:-3], globals(), locals(), ['*'])
+    for k in dir(m):
+        if k.startswith('test_'):
+            tst = getattr(m, k)
+            args = inspect.getargspec(tst).args
+            if 'Simulator' in args or 'RefSimulator' in args:
+                locals()[testfile[:-3] + '.' + k] = tst
+        if k.startswith('pytest'):
+            locals()[k] = getattr(m, k)
+
 
 if __name__ == '__main__':
-   unittest.main(testLoader=NengoTestLoader(sim_npy.Simulator))
+    pytest.main([__file__, '-v'])

--- a/nengo_ocl/test/test_sim_ocl.py
+++ b/nengo_ocl/test/test_sim_ocl.py
@@ -2,34 +2,64 @@
 Black-box testing of the sim_ocl Simulator.
 
 TestCase classes are added automatically from
-nengo.tests.helpers.simulator_test_cases, but
-you can still run individual test files like this:
+nengo.tests, but you can still run individual
+test files like this:
 
-$ python test/test_sim_ocl.py test_ensemble.TestEnsemble.test_lifrate
+$ py.test test/test_sim_ocl.py -k test_ensemble.test_scalar
+
+See http://pytest.org/latest/usage.html for more invocations.
 
 """
 
-from nengo_ocl.tricky_imports import unittest
-from nengo.tests.helpers import NengoTestLoader
-from nengo.tests.helpers import load_nengo_tests
+import inspect
+import os.path
+
+import nengo.tests
+import pyopencl as cl
+import pytest
+
 from nengo_ocl import sim_ocl
 
-import pyopencl as cl
 
 ctx = cl.create_some_context()
+
 
 def Ocl2Simulator(*args, **kwargs):
     kwargs['context'] = ctx
     return sim_ocl.Simulator(*args, **kwargs)
 
-# -- see comments in test_sim_npy.py for why these two
-#    classes are treated differently.
-from nengo.tests.test_simulator import TestSimulator, TestNonlinear
-TestSimulator.Simulator = staticmethod(Ocl2Simulator)
-TestNonlinear.Simulator = staticmethod(Ocl2Simulator)
 
-load_tests = load_nengo_tests(Ocl2Simulator)
+def pytest_funcarg__Simulator(request):
+    """the Simulator class being tested.
+
+    For this file, it's sim_npy.Simulator.
+    """
+    return Ocl2Simulator
+
+
+def pytest_funcarg__RefSimulator(request):
+    """the Simulator class being tested.
+
+    For this file, it's sim_npy.Simulator.
+    """
+    return Ocl2Simulator
+
+
+nengotestdir = os.path.dirname(nengo.tests.__file__)
+
+for testfile in os.listdir(nengotestdir):
+    if not testfile.startswith('test_') or not testfile.endswith('.py'):
+        continue
+    m = __import__("nengo.tests." + testfile[:-3], globals(), locals(), ['*'])
+    for k in dir(m):
+        if k.startswith('test_'):
+            tst = getattr(m, k)
+            args = inspect.getargspec(tst).args
+            if 'Simulator' in args or 'RefSimulator' in args:
+                locals()[testfile[:-3] + '.' + k] = tst
+        if k.startswith('pytest'):
+            locals()[k] = getattr(m, k)
 
 
 if __name__ == '__main__':
-   unittest.main(testLoader=NengoTestLoader(Ocl2Simulator))
+    pytest.main([__file__, '-v'])


### PR DESCRIPTION
This adds a requirement on py.test for testing the simulators on the Nengo unit tests. The implementation is a bit of a hack, but it won't require changes as Nengo unit tests change.

This PR goes along with https://github.com/ctn-waterloo/nengo/pull/233, so best wait until that's merged to merge this.
